### PR TITLE
Fix code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/ElementalDB.py
+++ b/ElementalDB.py
@@ -25,7 +25,10 @@ class ElementalDB:
 
     def save_table(self, table_name):
         table = self.tables[table_name]
-        with open(os.path.join(self.db_directory, f'{table_name}.json'), 'wb') as f:
+        fullpath = os.path.normpath(os.path.join(self.db_directory, f'{table_name}.json'))
+        if not fullpath.startswith(self.db_directory):
+            raise Exception("Invalid table name")
+        with open(fullpath, 'wb') as f:
             f.write(orjson.dumps(table))
 
     def create_table(self, table_name, columns, foreign_keys=None):


### PR DESCRIPTION
Fixes [https://github.com/cools9/ElementalDB/security/code-scanning/1](https://github.com/cools9/ElementalDB/security/code-scanning/1)

To fix the problem, we need to ensure that the constructed file path is contained within a safe root folder. This can be achieved by normalizing the path using `os.path.normpath` and then checking that the normalized path starts with the root directory. This approach will prevent path traversal attacks by ensuring that the `table_name` cannot be manipulated to access files outside the intended directory.

1. Normalize the constructed file path using `os.path.normpath`.
2. Check that the normalized path starts with the `db_directory`.
3. Raise an exception if the check fails.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
